### PR TITLE
Faster Player

### DIFF
--- a/Podcast/Episode.swift
+++ b/Podcast/Episode.swift
@@ -40,7 +40,7 @@ class Episode: NSObject {
         self.smallArtworkImageURL = smallArtworkImageURL
         self.largeArtworkImageURL = largeArtworkImageURL
         if audioURL == nil { //TAKE THIS OUT LATER ONLY FOR PLAYER STATIC DATA
-            self.audioURL = URL(string: "https://play.podtrac.com/npr-344098539/npr.mc.tritondigital.com/WAITWAIT_PODCAST/media/anon.npr-podcasts/podcast/344098539/517256651/npr_517256651.mp3?orgId=1&d=2981&p=344098539&story=517256651&t=podcast&e=517256651&ft=pod&f=344098539")
+            self.audioURL = URL(string: "https://play.podtrac.com/npr-510298/npr.mc.tritondigital.com/NPR_510298/media/anon.npr-mp3/npr/ted/2017/02/20170215_ted_tedpod.mp3?orgId=1&d=3241&p=510298&story=515438384&t=podcast&e=515438384&ft=pod&f=510298")
         } else {
             self.audioURL = audioURL
         }

--- a/Podcast/Player.swift
+++ b/Podcast/Player.swift
@@ -12,6 +12,9 @@ class Player: NSObject {
     static let sharedInstance = Player()
     private override init() {
         player = AVPlayer()
+        if #available(iOS 10, *) {
+            player.automaticallyWaitsToMinimizeStalling = false
+        }
         autoplayEnabled = true
         currentItemPrepared = false
         isScrubbing = false
@@ -59,6 +62,9 @@ class Player: NSObject {
                 print(error)
             }
             player = AVPlayer()
+            if #available(iOS 10, *) {
+                player.automaticallyWaitsToMinimizeStalling = false
+            }
         }
         
         // cleanup any previous AVPlayerItem


### PR DESCRIPTION
By default in iOS 10 and later, the AVPlayer stalls until it calculates that it could play until the end of the AVPlayerItem at the current download rate. However, for large podcast audio files this calculation is iffy and leads to big delays when a new track is put into the Player, even though we can safely start playing right away. This PR makes this small change to make the Player play immediately by default.