### PR TITLE
changing search view indicator so indicator view doesn't display over…

### DIFF
--- a/Podcast/PlayButton.swift
+++ b/Podcast/PlayButton.swift
@@ -15,7 +15,7 @@ class PlayButton: UIButton {
         setImage(#imageLiteral(resourceName: "play_feed_icon"), for: .normal)
         setImage(#imageLiteral(resourceName: "play_feed_icon_selected"), for: .selected)
         setTitle("  Play", for: .normal)
-        setTitle("  Now Playing", for: .selected)
+        setTitle("  Playing", for: .selected)
         titleLabel?.font = .systemFont(ofSize: 12, weight: UIFontWeightRegular)
         setTitleColor(.podcastBlack, for: .normal)
         setTitleColor(.podcastGreenBlue, for: .selected)

--- a/Podcast/SearchTableViewController.swift
+++ b/Podcast/SearchTableViewController.swift
@@ -58,6 +58,7 @@ class SearchTableViewController: UITableViewController, SearchEpisodeTableViewCe
         .tags: []]
     
     var cellDelegate: SearchTableViewControllerDelegate?
+    var loadingIndicatorView: NVActivityIndicatorView?
     
     var currentlyPlayingIndexPath: IndexPath?
     
@@ -71,6 +72,9 @@ class SearchTableViewController: UITableViewController, SearchEpisodeTableViewCe
             self.fetchData(completion: nil)
         }
         automaticallyAdjustsScrollViewInsets = false
+        loadingIndicatorView = createLoadingAnimationView()
+        loadingIndicatorView!.center = CGPoint(x: view.frame.width/2, y: view.frame.height/2)
+        view.addSubview(loadingIndicatorView!)
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/Podcast/SearchTableViewController.swift
+++ b/Podcast/SearchTableViewController.swift
@@ -64,6 +64,7 @@ class SearchTableViewController: UITableViewController, SearchEpisodeTableViewCe
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         guard let (cellIdentifier, cellClass) = cellIdentifiersClasses[searchType] else { return }
         tableView.register(cellClass, forCellReuseIdentifier: cellIdentifier)
         tableView.showsVerticalScrollIndicator = false
@@ -73,7 +74,7 @@ class SearchTableViewController: UITableViewController, SearchEpisodeTableViewCe
         }
         automaticallyAdjustsScrollViewInsets = false
         loadingIndicatorView = createLoadingAnimationView()
-        loadingIndicatorView!.center = CGPoint(x: view.frame.width/2, y: view.frame.height/2)
+        loadingIndicatorView!.center = CGPoint(x: view.frame.width/2, y: view.frame.height/2 - appDelegate.tabBarController.tabBarHeight)
         view.addSubview(loadingIndicatorView!)
     }
     

--- a/Podcast/TabbedPageViewController.swift
+++ b/Podcast/TabbedPageViewController.swift
@@ -37,7 +37,6 @@ class TabbedPageViewController: UIViewController, UIPageViewControllerDataSource
     weak var searchResultsDelegate: TabbedViewControllerSearchResultsControllerDelegate?
     weak var searchRequestsDelegate: SearchRequestsDelegate?
     var tabBar: UnderlineTabBarView!
-    //var loadingActivityIndicator: NVActivityIndicatorView!
     let tabSections: [SearchType] = [.episodes, .series, .people, .tags]
     
     var pageViewController: UIPageViewController!


### PR DESCRIPTION
I think this is better view experience and we can cater each controller separately when they all have their own search indicator views 