### PR TITLE
Lower priority for problematic height constraints

### DIFF
--- a/Podcast/FeedElementTableViewCell.swift
+++ b/Podcast/FeedElementTableViewCell.swift
@@ -43,7 +43,7 @@ extension FeedElementTableViewCell where Self: UITableViewCell {
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()
             make.top.equalToSuperview()
-            make.height.equalTo(supplierViewHeight) // should make this generic
+            make.height.equalTo(supplierViewHeight).priority(999) // should make this generic
         }
 
         subjectView.snp.makeConstraints { make in

--- a/Podcast/SearchTableViewController.swift
+++ b/Podcast/SearchTableViewController.swift
@@ -106,7 +106,7 @@ class SearchTableViewController: ViewController, UITableViewDelegate, UITableVie
 
             searchITunesHeaderView?.snp.makeConstraints { make in
                 make.width.top.centerX.equalToSuperview()
-                make.height.equalTo(searchITunesHeaderHeight)
+                make.height.equalTo(searchITunesHeaderHeight).priority(999)
             }
         }
     }


### PR DESCRIPTION
I strongly suspect constraint breaking is due to an inconsistency with UITableViews and UICollectionView row/item sizes and our programmatic constraints that create them.

A common practice is to lower the priority of created constraints to let iOS have the final say regarding the intrinsic size of our cells, often to 999. This way, iOS's encapsulated layout constraints with the default priority of 1000 have precedence, and no constraints end up broken at the end of the day.