### PR TITLE
fixing listening history bug / pull to refresh bug

### DIFF
--- a/Podcast/BookmarkViewController.swift
+++ b/Podcast/BookmarkViewController.swift
@@ -33,8 +33,7 @@ class BookmarkViewController: ViewController, EmptyStateTableViewDelegate, UITab
         bookmarkTableView.rowHeight = BookmarkTableViewCell.height
         bookmarkTableView.reloadData()
         mainScrollView = bookmarkTableView
-        
-        bookmarkTableView.refreshControl?.addTarget(self, action: #selector(fetchEpisodes), for: .valueChanged)
+
         fetchEpisodes()
     }
     
@@ -129,18 +128,22 @@ class BookmarkViewController: ViewController, EmptyStateTableViewDelegate, UITab
     //MARK
     //MARK - Endpoint Requests
     //MARK
-    
+    func emptyStateTableViewHandleRefresh() {
+        fetchEpisodes()
+    }
+
     @objc func fetchEpisodes() {
         let endpointRequest = FetchBookmarksEndpointRequest()
         endpointRequest.success = { request in
-            self.bookmarkTableView.endRefreshing()
             guard let newEpisodes = request.processedResponseValue as? [Episode] else { return }
             self.episodes = newEpisodes
+            self.bookmarkTableView.reloadData()
+            self.bookmarkTableView.endRefreshing()
             self.bookmarkTableView.stopLoadingAnimation()
-            self.bookmarkTableView.reloadSections([0] , with: .automatic)
         }
         endpointRequest.failure = { _ in
             self.bookmarkTableView.endRefreshing()
+            self.bookmarkTableView.stopLoadingAnimation()
         }
         System.endpointRequestQueue.addOperation(endpointRequest)
     }

--- a/Podcast/EmptyStateTableView.swift
+++ b/Podcast/EmptyStateTableView.swift
@@ -10,6 +10,7 @@ import NVActivityIndicatorView
 
 protocol EmptyStateTableViewDelegate: class {
     func didPressEmptyStateViewActionItem()
+    func emptyStateTableViewHandleRefresh()
 }
 
 /**
@@ -44,6 +45,7 @@ class EmptyStateTableView: UITableView, EmptyStateViewDelegate {
         if isRefreshable {
             refreshControl = UIRefreshControl()
             refreshControl!.tintColor = .sea
+            refreshControl?.addTarget(self, action: #selector(handleRefresh), for: .valueChanged)
         }
     }
     
@@ -93,5 +95,10 @@ class EmptyStateTableView: UITableView, EmptyStateViewDelegate {
         if let control = refreshControl {
             if !control.isRefreshing { control.beginRefreshing() }
         }
+    }
+
+    // override this function in view controllers that use EmptyStateTableView and isRefreshable
+    @objc func handleRefresh() {
+        emptyStateTableViewDelegate?.emptyStateTableViewHandleRefresh()
     }
 }

--- a/Podcast/FeedViewController.swift
+++ b/Podcast/FeedViewController.swift
@@ -45,7 +45,7 @@ class FeedViewController: ViewController {
         feedTableView.rowHeight = UITableViewAutomaticDimension
         feedTableView.estimatedRowHeight = 200.0
         feedTableView.reloadData()
-        feedTableView.addInfiniteScroll { (tableView) -> Void in
+        feedTableView.addInfiniteScroll { _ -> Void in
             self.fetchFeedElements(isPullToRefresh: false)
         }
         //tells the infinite scroll when to stop
@@ -55,7 +55,7 @@ class FeedViewController: ViewController {
         
         feedTableView.infiniteScrollIndicatorView = LoadingAnimatorUtilities.createInfiniteScrollAnimator()
 
-        fetchFeedElements(isPullToRefresh: true)
+        fetchFeedElements()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -79,10 +79,10 @@ class FeedViewController: ViewController {
     //MARK - Endpoint Requests
     //MARK
     func emptyStateTableViewHandleRefresh() {
-        fetchFeedElements(isPullToRefresh: true)
+        fetchFeedElements()
     }
 
-    func fetchFeedElements(isPullToRefresh: Bool) {
+    func fetchFeedElements(isPullToRefresh: Bool = true) {
         let fetchFeedEndpointRequest = FetchFeedEndpointRequest(maxtime: self.feedMaxTime, pageSize: pageSize)
         
         fetchFeedEndpointRequest.success = { (endpoint) in

--- a/Podcast/FeedViewController.swift
+++ b/Podcast/FeedViewController.swift
@@ -46,7 +46,7 @@ class FeedViewController: ViewController {
         feedTableView.estimatedRowHeight = 200.0
         feedTableView.reloadData()
         feedTableView.addInfiniteScroll { (tableView) -> Void in
-            self.fetchCards(isPullToRefresh: false)
+            self.fetchFeedElements(isPullToRefresh: false)
         }
         //tells the infinite scroll when to stop
         feedTableView.setShouldShowInfiniteScrollHandler { _ -> Bool in
@@ -55,9 +55,7 @@ class FeedViewController: ViewController {
         
         feedTableView.infiniteScrollIndicatorView = LoadingAnimatorUtilities.createInfiniteScrollAnimator()
 
-        feedTableView.refreshControl?.addTarget(self, action: #selector(fetchCards), for: .valueChanged)
-        
-        fetchCards()
+        fetchFeedElements(isPullToRefresh: true)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -80,7 +78,11 @@ class FeedViewController: ViewController {
     //MARK
     //MARK - Endpoint Requests
     //MARK
-    @objc func fetchCards(isPullToRefresh: Bool = true) {
+    func emptyStateTableViewHandleRefresh() {
+        fetchFeedElements(isPullToRefresh: true)
+    }
+
+    func fetchFeedElements(isPullToRefresh: Bool) {
         let fetchFeedEndpointRequest = FetchFeedEndpointRequest(maxtime: self.feedMaxTime, pageSize: pageSize)
         
         fetchFeedEndpointRequest.success = { (endpoint) in

--- a/Podcast/FollowerFollowingViewController.swift
+++ b/Podcast/FollowerFollowingViewController.swift
@@ -13,7 +13,7 @@
 import UIKit
 import NVActivityIndicatorView
 
-class FollowerFollowingViewController: ViewController, UITableViewDataSource, UITableViewDelegate, SearchPeopleTableViewCellDelegate {
+class FollowerFollowingViewController: ViewController, UITableViewDataSource, UITableViewDelegate, SearchPeopleTableViewCellDelegate, EmptyStateTableViewDelegate {
     
     let cellIdentifier = "searchUsersCell"
     
@@ -39,6 +39,7 @@ class FollowerFollowingViewController: ViewController, UITableViewDataSource, UI
 
         // Do any additional setup after loading the view.
         usersTableView = EmptyStateTableView(frame: view.frame, type: followersOrFollowings == .Followers ? .followers : .following, isRefreshable: true)
+        usersTableView.emptyStateTableViewDelegate = self
         usersTableView.delegate = self
         usersTableView.dataSource = self
         usersTableView.backgroundColor = .clear
@@ -46,8 +47,6 @@ class FollowerFollowingViewController: ViewController, UITableViewDataSource, UI
         usersTableView.reloadData()
         mainScrollView = usersTableView
         view.addSubview(usersTableView)
-        
-        usersTableView.refreshControl?.addTarget(self, action: #selector(FollowerFollowingViewController.handleRefresh), for: .valueChanged)
         
         usersTableView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -61,9 +60,14 @@ class FollowerFollowingViewController: ViewController, UITableViewDataSource, UI
         usersTableView.reloadData()
     }
     
-    @objc func handleRefresh() {
+    func emptyStateTableViewHandleRefresh() {
         fetchUsers()
     }
+
+    func didPressEmptyStateViewActionItem() {
+        // delegate protocol
+    }
+
     
     func fetchUsers() {
         let endpointRequest = FetchUserFollowsByIDRequest(userId: currentViewUser.id, type: followersOrFollowings)

--- a/Podcast/ListeningHistoryViewController.swift
+++ b/Podcast/ListeningHistoryViewController.swift
@@ -25,7 +25,6 @@ class ListeningHistoryViewController: ViewController, UITableViewDelegate, UITab
     var episodeSet = Set<Episode>()
     var continueInfiniteScroll: Bool = true
     let pageSize: Int = 20
-    var offset: Int = 0
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -52,9 +51,7 @@ class ListeningHistoryViewController: ViewController, UITableViewDelegate, UITab
             return self.continueInfiniteScroll
         }
 
-        self.fetchEpisodes()
-    
-        listeningHistoryTableView.refreshControl?.addTarget(self, action: #selector(fetchEpisodes), for: .valueChanged)
+        self.fetchEpisodes(refresh: true)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -115,20 +112,33 @@ class ListeningHistoryViewController: ViewController, UITableViewDelegate, UITab
     //MARK
     //MARK - Endpoint Requests
     //MARK
+    func emptyStateTableViewHandleRefresh() {
+        fetchEpisodes(refresh: true)
+    }
 
-    @objc func fetchEpisodes(refresh: Bool = true) {
+    func fetchEpisodes(refresh: Bool) {
+        let offset: Int
         if refresh {
             offset = 0
+        } else {
+            offset = self.episodes.count
         }
         let historyRequest = FetchListeningHistoryEndpointRequest(offset: offset, max: pageSize)
         historyRequest.success = { request in
             guard let newEpisodes = request.processedResponseValue as? [Episode] else { return }
-            let oldCount = self.episodeSet.count
+            var episodesToAdd: [Episode] = []
             for episode in newEpisodes {
-                self.episodeSet.insert(episode)
+                if !self.episodeSet.contains(episode) { //only add episodes we haven't seen
+                    episodesToAdd.append(episode)
+                    self.episodeSet.insert(episode)
+                }
             }
-            if oldCount == self.episodeSet.count { self.continueInfiniteScroll = false }
-            self.episodes = self.episodeSet.sorted { (e1,e2) in e1.dateCreated > e2.dateCreated } //TODO: order these by listening history creation
+            if refresh { //if we are at a pull to refresh add episodes to beginning
+                self.episodes = episodesToAdd + self.episodes
+            } else {
+                self.episodes = self.episodes + episodesToAdd
+            }
+            if episodesToAdd.isEmpty && !refresh { self.continueInfiniteScroll = false }
             self.listeningHistoryTableView.endRefreshing()
             self.listeningHistoryTableView.stopLoadingAnimation()
             self.listeningHistoryTableView.finishInfiniteScroll()

--- a/Podcast/ListeningHistoryViewController.swift
+++ b/Podcast/ListeningHistoryViewController.swift
@@ -51,7 +51,7 @@ class ListeningHistoryViewController: ViewController, UITableViewDelegate, UITab
             return self.continueInfiniteScroll
         }
 
-        self.fetchEpisodes(refresh: true)
+        self.fetchEpisodes()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -113,10 +113,10 @@ class ListeningHistoryViewController: ViewController, UITableViewDelegate, UITab
     //MARK - Endpoint Requests
     //MARK
     func emptyStateTableViewHandleRefresh() {
-        fetchEpisodes(refresh: true)
+        fetchEpisodes()
     }
 
-    func fetchEpisodes(refresh: Bool) {
+    func fetchEpisodes(refresh: Bool = true) {
         let offset: Int
         if refresh {
             offset = 0


### PR DESCRIPTION
- Now listening history actually is paginated (bug before)
- Fixes all pull to refresh bugs that used to have a default boolean in the fetch endpoint request (apparently this default boolean will always be false when calling from a `#selector`)
- Refactors adding refresh control to inside `EmptyStateTableView`