### PR TITLE
transfer search query to search itunes

### DIFF
--- a/Podcast/SearchITunesViewController.swift
+++ b/Podcast/SearchITunesViewController.swift
@@ -13,10 +13,16 @@ class SearchITunesViewController: ViewController, UITableViewDelegate, UITableVi
     
     var searchController: UISearchController!
     var tableView: EmptyStateTableView!
+    var initialQuery: String?
     
     var searchResults: [Series] = []
     let seriesCellIdentifier = "SeriesCell"
     let seriesCellHeight: CGFloat = 95
+
+    convenience init(query: String?) {
+        self.init()
+        initialQuery = query
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -48,7 +54,7 @@ class SearchITunesViewController: ViewController, UITableViewDelegate, UITableVi
         searchController.searchBar.showsSearchResultsButton = false
         searchController.searchBar.showsScopeBar = false
         searchController.searchBar.searchBarStyle = .minimal
-        searchController.searchBar.placeholder = "Search"
+        searchController.searchBar.text = initialQuery
         searchController.searchBar.delegate = self
         definesPresentationContext = true
     }
@@ -117,6 +123,10 @@ class SearchITunesViewController: ViewController, UITableViewDelegate, UITableVi
     
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         tableView.isHidden = false
+    }
+
+    func didPresentSearchController(_ searchController: UISearchController) {
+        searchController.searchBar.becomeFirstResponder()
     }
     
     // MARK: SearchSeriesCellDelegate

--- a/Podcast/SearchITunesViewController.swift
+++ b/Podcast/SearchITunesViewController.swift
@@ -13,13 +13,13 @@ class SearchITunesViewController: ViewController, UITableViewDelegate, UITableVi
     
     var searchController: UISearchController!
     var tableView: EmptyStateTableView!
-    var initialQuery: String?
+    var initialQuery: String!
     
     var searchResults: [Series] = []
     let seriesCellIdentifier = "SeriesCell"
     let seriesCellHeight: CGFloat = 95
 
-    convenience init(query: String?) {
+    convenience init(query: String) {
         self.init()
         initialQuery = query
     }

--- a/Podcast/SearchViewController.swift
+++ b/Podcast/SearchViewController.swift
@@ -107,7 +107,7 @@ class SearchViewController: ViewController, UISearchControllerDelegate, UITableV
     }
     
     func didTapOnSearchITunes() {
-        let searchITunesViewController = SearchITunesViewController()
+        let searchITunesViewController = SearchITunesViewController(query: searchController.searchBar.text)
         navigationController?.pushViewController(searchITunesViewController, animated: true)
     }
     

--- a/Podcast/SearchViewController.swift
+++ b/Podcast/SearchViewController.swift
@@ -107,7 +107,7 @@ class SearchViewController: ViewController, UISearchControllerDelegate, UITableV
     }
     
     func didTapOnSearchITunes() {
-        let searchITunesViewController = SearchITunesViewController(query: searchController.searchBar.text)
+        let searchITunesViewController = SearchITunesViewController(query: searchController.searchBar.text ?? "")
         navigationController?.pushViewController(searchITunesViewController, animated: true)
     }
     


### PR DESCRIPTION
- fixes ux of having to re-type search query
- automatically displays search controller w/keyboard active