### PR TITLE
Add CodeOwners File

### DIFF
--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @cuappdev/podcast-ios will be requested for
+# review when someone opens a pull request.
+*       @cuappdev/podcast-ios


### PR DESCRIPTION
This is something we have started doing at my place of work.

Anytime anyone makes a PR, the @cuappdev/podcast-ios team would be alerted.

Theoretically,  @cuappdev/developers would have a child team, @cuappdev/podcast. That team would have @cuappdev/podcast-ios, @cuappdev/podcast-backend, @cuappdev/podcast-designers etc. as child teams. Noticed you guys always request the same people for CR so it might be something to try out.

Curious how CODEOWNERS works? [Check it out](https://help.github.com/articles/about-codeowners/).